### PR TITLE
fix: edge browser "Zero or duplicate tokens or token signing keys" error

### DIFF
--- a/packages/web-push/lib/payload.ts
+++ b/packages/web-push/lib/payload.ts
@@ -24,11 +24,11 @@ export async function buildPushPayload(
     headers: {
       ...headers,
 
-      'crypto-key': `keyid=p256dh;dh=${encodeBase64Url(
+      'crypto-key': `dh=${encodeBase64Url(
         encrypted.localPublicKeyBytes,
       )};${headers['crypto-key']}`,
 
-      encryption: `keyid=p256dh;salt=${encodeBase64Url(encrypted.salt)}`,
+      encryption: `salt=${encodeBase64Url(encrypted.salt)}`,
 
       ttl: (message.options?.ttl || 60).toString(),
       ...(message.options?.urgency && {

--- a/packages/web-push/test/__snapshots__/notification.test.ts.snap
+++ b/packages/web-push/test/__snapshots__/notification.test.ts.snap
@@ -48,8 +48,8 @@ exports[`buildPushPayload 3`] = `
   "content-encoding": "aesgcm",
   "content-length": "36",
   "content-type": "application/octet-stream",
-  "crypto-key": "keyid=p256dh;dh=BO6-TCHINeAfMhq44SQLnR-3NZnAfwe2n-CjcESbHlOcJkx_8JqbcwRJMd5zrZouJbIUe2AkFnhoDavSymNyOA0;p256ecdsa=BKKXE3jJV5UJ6c8HVPam6DvMPGZK26r-M7ojsO2T_KdjdeMT2d7oQpaO-VI3o3wn33mQ8JlHta3OSJ5f67Ac5ZY",
-  "encryption": "keyid=p256dh;salt=4CQCKEyyOT_LysC17rsMXQ",
+  "crypto-key": "dh=BO6-TCHINeAfMhq44SQLnR-3NZnAfwe2n-CjcESbHlOcJkx_8JqbcwRJMd5zrZouJbIUe2AkFnhoDavSymNyOA0;p256ecdsa=BKKXE3jJV5UJ6c8HVPam6DvMPGZK26r-M7ojsO2T_KdjdeMT2d7oQpaO-VI3o3wn33mQ8JlHta3OSJ5f67Ac5ZY",
+  "encryption": "salt=4CQCKEyyOT_LysC17rsMXQ",
   "ttl": "60",
 }
 `;

--- a/packages/web-push/test/fixtures.ts
+++ b/packages/web-push/test/fixtures.ts
@@ -1,7 +1,7 @@
 import type { PushSubscription } from '../lib/types.js';
 
 export const fakeSubscriptions = {
-  test: {
+  chrome: {
     endpoint:
       'https://fcm.googleapis.com/fcm/send/fL4MGn77FGc:APA91bE9RjT5iS_lfuBIm7PeOS2789EzyWGbUrh-viIAgsGbJIG-Rc65ipPt8hFS6aLwiyvyfXsSIVTZTuISxPUo3kcaklfv_WYpZ4g1g8jY6wChNoHkRmDpGN7qFgI2SkrV2SxYlL-r',
     expirationTime: null,
@@ -9,6 +9,16 @@ export const fakeSubscriptions = {
       p256dh:
         'BJSK63fSr4N3Vrx2DPFmRrGLglmDOZBFy5AwUDINlEFMQYHjDS2YjZbIYTuOGQVp4ZbzJKki6cCYcKsMHSBF9-Y',
       auth: 'lzqdvQzre8BPRpJTvFJZng',
+    },
+  },
+  edge: {
+    endpoint:
+      'https://wns2-sg2p.notify.windows.com/w/?token=BQYAAAAOqpMScCyZs07b3Rhi7WoqEBYPH9pHcOxdJ7lGF0E9YcvLHxBniuEp3FT3%2fHyZcyP%2fCPuqaZSQcIs%2bHn%2f5aQAk9l1BwojHAE2ZRuzMWEClZzdm3A661RAujyNyEoVeKjeTL872YTFMxb0AeEWrAMhQ969Pm9Pq93yunKqL8N0vcCwJ%2bSuznNCzDZgbAst2l2EWbDqRUeUClJxozU9SFowOV0ypMdluq%2bionNVEpJYo2JmnJs%2bQbVUv4MAH%2fKx3pe4CftTkDkgqWWcMhBkVwpexn6%2bNo7F5Ae1kM1vFhruf6%2f4Rc47cqvwSsbmcxj3MhGI%3d',
+    expirationTime: null,
+    keys: {
+      p256dh:
+        'BOHAcPFrsyWQchMJfijwJbLMV2HVBZHumzQPcgj_hhuXpbqaQunE09dRbWOasPW13e2K7RzQNVoJ7z1iXAFrypY',
+      auth: 'KxoJGb-hSSi8QFDyld-P7Q',
     },
   },
 } satisfies Record<string, PushSubscription>;

--- a/packages/web-push/test/fixtures.ts
+++ b/packages/web-push/test/fixtures.ts
@@ -13,12 +13,12 @@ export const fakeSubscriptions = {
   },
   edge: {
     endpoint:
-      'https://wns2-sg2p.notify.windows.com/w/?token=BQYAAAAOqpMScCyZs07b3Rhi7WoqEBYPH9pHcOxdJ7lGF0E9YcvLHxBniuEp3FT3%2fHyZcyP%2fCPuqaZSQcIs%2bHn%2f5aQAk9l1BwojHAE2ZRuzMWEClZzdm3A661RAujyNyEoVeKjeTL872YTFMxb0AeEWrAMhQ969Pm9Pq93yunKqL8N0vcCwJ%2bSuznNCzDZgbAst2l2EWbDqRUeUClJxozU9SFowOV0ypMdluq%2bionNVEpJYo2JmnJs%2bQbVUv4MAH%2fKx3pe4CftTkDkgqWWcMhBkVwpexn6%2bNo7F5Ae1kM1vFhruf6%2f4Rc47cqvwSsbmcxj3MhGI%3d',
+      'https://wns2-sg2p.notify.windows.com/w/?token=BQYAAAALwNoB%2fBFE0R6H%2bayc5WRfMVkJlB3mHXSmsCTKWeZZM%2faOvneI8DaE%2fQeCC6uE17dj%2bPNz9drmi5bEvrNRTs8hzCS2abTpc4lfS9XbebI8lqe%2bXcPerho8q5SnWcTk4GURFakuZUYI6e0xMnTG%2bpvFxFatlhq4CELEEyo9%2fAP%2fHMx8tPCSXsh3sSFDtx6MkDnMHmR%2fUvcCrnLbXCDiseZ40bQI6a5tRmOM0izm0Gfc%2foKWmce8JUk2TRtm%2fecPR1F0X%2bVj4JQsDAR7Kx56HUCONLNMzuVm%2b9O6Yp1bLUfnp1QJyVOVyyj6DQfG%2bOOsikh%2bd2foJpWHggpFenW3NiT3',
     expirationTime: null,
     keys: {
       p256dh:
-        'BOHAcPFrsyWQchMJfijwJbLMV2HVBZHumzQPcgj_hhuXpbqaQunE09dRbWOasPW13e2K7RzQNVoJ7z1iXAFrypY',
-      auth: 'KxoJGb-hSSi8QFDyld-P7Q',
+        'BDPQRxcMhoXtPqJvQ9Kp-FGsQexasWXvh0RTE15Y0qbxKLFZ6eG3U90RJQFkb_SdAB_YzbIm7hcvzn1yAzNZbxs',
+      auth: 'XGCMxdgIGIp7SNs3kb4x7g',
     },
   },
 } satisfies Record<string, PushSubscription>;

--- a/packages/web-push/test/notification.test.ts
+++ b/packages/web-push/test/notification.test.ts
@@ -59,7 +59,7 @@ describe('', () => {
   test('buildPushPayload', async () => {
     vi.setSystemTime(Date.UTC(2000, 1, 1, 13, 0, 0, 0));
 
-    const subscription = fakeSubscriptions.test;
+    const subscription = fakeSubscriptions.chrome;
 
     const requestInfo = await buildPushPayload(
       {

--- a/packages/web-push/test/push.test.ts
+++ b/packages/web-push/test/push.test.ts
@@ -3,7 +3,7 @@ import { buildPushPayload, type PushMessage } from '../lib/main.js';
 import { fakeSubscriptions, fakeVapid } from './fixtures.js';
 
 describe('Payload', () => {
-  test('Fake Subscription', async () => {
+  test('Fake Chrome Subscription', async () => {
     const message: PushMessage = {
       data: 'Some text',
       options: {
@@ -15,7 +15,29 @@ describe('Payload', () => {
       },
     };
 
-    const subscription = fakeSubscriptions.test;
+    const subscription = fakeSubscriptions.chrome;
+
+    const init = await buildPushPayload(message, subscription, fakeVapid);
+    const res = await fetch(subscription.endpoint, init);
+
+    await expect(res.text()).resolves.toMatchInlineSnapshot('""');
+    expect(res.statusText).toMatchInlineSnapshot('"Created"');
+    expect(res.status).toMatchInlineSnapshot('201');
+  });
+
+  test('Fake Edge Subscription', async () => {
+    const message: PushMessage = {
+      data: 'Some text',
+      options: {
+        ttl: 60,
+        // Topics are strings that can be used to replace a pending messages with
+        // a new message if they have matching topic names
+        topic: 'from-test-env',
+        urgency: 'high',
+      },
+    };
+
+    const subscription = fakeSubscriptions.edge;
 
     const init = await buildPushPayload(message, subscription, fakeVapid);
     const res = await fetch(subscription.endpoint, init);

--- a/packages/web-push/test/push.test.ts
+++ b/packages/web-push/test/push.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'vitest';
 import { buildPushPayload, type PushMessage } from '../lib/main.js';
 import { fakeSubscriptions, fakeVapid } from './fixtures.js';
 
-describe('Payload', () => {
+describe('Payload Integration', () => {
   test('Fake Chrome Subscription', async () => {
     const message: PushMessage = {
       data: 'Some text',
@@ -30,7 +30,7 @@ describe('Payload', () => {
       data: 'Some text',
       options: {
         ttl: 60,
-        // Topics are strings that can be used to replace a pending messages with
+        // Topics are strings that can be used to replace pending messages with
         // a new message if they have matching topic names
         topic: 'from-test-env',
         urgency: 'high',
@@ -45,5 +45,9 @@ describe('Payload', () => {
     await expect(res.text()).resolves.toMatchInlineSnapshot('""');
     expect(res.statusText).toMatchInlineSnapshot('"Created"');
     expect(res.status).toMatchInlineSnapshot('201');
+
+    // seemingly Edge specific headers, static so we can check them here
+    expect(res.headers.get('x-wns-notificationstatus')).toBe('received');
+    expect(res.headers.get('x-wns-status')).toBe('received');
   });
 });

--- a/packages/web-push/test/vapid.test.ts
+++ b/packages/web-push/test/vapid.test.ts
@@ -17,6 +17,6 @@ describe('VAPID', () => {
   test('Headers', async () => {
     vi.setSystemTime(new Date(2000, 1, 1, 13));
 
-    await vapidHeaders(fakeSubscriptions.test, fakeVapid);
+    await vapidHeaders(fakeSubscriptions.chrome, fakeVapid);
   });
 });


### PR DESCRIPTION
Todo:

- [x] Chrome seems flaky with this change implemented. Arbitrarily responds with "invalid jwt"
- [x] Microsoft are very diligent with pruning test subscriptions in Edge. Need to create one that doesnt get nuked (this is the cause of current build failure)

fixes #13